### PR TITLE
Rename 'AuthenticatedEncryption' class to 'Encryption' 

### DIFF
--- a/AuthenticatedEncryption.Tests/AuthenticatedEncryptionTests.cs
+++ b/AuthenticatedEncryption.Tests/AuthenticatedEncryptionTests.cs
@@ -10,11 +10,11 @@
         public void Encrypt_WhenGivenInput_EncryptsAndDecryptsCorrectly()
         {
             const string Input = "this is a test input string";
-            var cryptKey = AuthenticatedEncryption.NewKey();
-            var authKey = AuthenticatedEncryption.NewKey();
+            var cryptKey = Encryption.NewKey();
+            var authKey = Encryption.NewKey();
 
-            var cipherText = AuthenticatedEncryption.Encrypt(Input, cryptKey, authKey);
-            var plainText = AuthenticatedEncryption.Decrypt(cipherText, cryptKey, authKey);
+            var cipherText = Encryption.Encrypt(Input, cryptKey, authKey);
+            var plainText = Encryption.Decrypt(cipherText, cryptKey, authKey);
 
             plainText.ShouldBe(Input);
         }
@@ -29,7 +29,7 @@
             var cryptKey = Convert.FromBase64String(CryptKey);
             var authKey = Convert.FromBase64String(AuthKey);
 
-            var plainText = AuthenticatedEncryption.Decrypt(CipherText, cryptKey, authKey);
+            var plainText = Encryption.Decrypt(CipherText, cryptKey, authKey);
 
             plainText.ShouldBe(Input);
         }

--- a/AuthenticatedEncryption/AuthenticatedEncryption.csproj
+++ b/AuthenticatedEncryption/AuthenticatedEncryption.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net45;netstandard1.4</TargetFrameworks>
     <AssemblyName>AuthenticatedEncryption</AssemblyName>
     <PackageId>AuthenticatedEncryption</PackageId>

--- a/AuthenticatedEncryption/Encryption.cs
+++ b/AuthenticatedEncryption/Encryption.cs
@@ -5,7 +5,7 @@
     using System.Security.Cryptography;
     using System.Text;
 
-    public static class AuthenticatedEncryption
+    public static class Encryption
     {
         private static readonly RandomNumberGenerator Random = RandomNumberGenerator.Create();
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ The library consists of a single static class. This makes it very easy to use. I
 This is a simple example of encrypting and decrypting some string:
 
 ```c#
-const string Input = "this is a test input string";
-var cryptKey = AuthenticatedEncryption.NewKey();
-var authKey = AuthenticatedEncryption.NewKey();
+using AuthenticatedEncryption;
 
-var cipherText = AuthenticatedEncryption.Encrypt(Input, cryptKey, authKey);
-var plainText = AuthenticatedEncryption.Decrypt(cipherText, cryptKey, authKey);
+const string Input = "this is a test input string";
+var cryptKey = Encryption.NewKey();
+var authKey = Encryption.NewKey();
+
+var cipherText = Encryption.Encrypt(Input, cryptKey, authKey);
+var plainText = Encryption.Decrypt(cipherText, cryptKey, authKey);
 ```
 
 ## Maintainer(s)


### PR DESCRIPTION
Renaming this class allows it to be referenced without either of the following undesirable requirements.
1. Requiring the class to be redundantly qualified with the containing namespace name.
2. Requiring that the `using AuthenticatedEncryption;` statement be placed _within_ a consuming project's namespace. (After the rename, the using statement can be placed outside a namespace declaration, which is a common convention for many projects.)

Additionally, I bumped the version number to `2.0.0` because this change is breaking and updated the readme with a corrected example. 

Closes #11.