### PR TITLE
Upgrade to .net 8 + upgrade all dependencies in the test project

### DIFF
--- a/AuthenticatedEncryption.Tests/AuthenticatedEncryption.Tests.csproj
+++ b/AuthenticatedEncryption.Tests/AuthenticatedEncryption.Tests.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>AuthenticatedEncryption.Tests</AssemblyName>
     <PackageId>AuthenticatedEncryption.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -23,10 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
-    <PackageReference Include="Shouldly" Version="2.8.2" />
-    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AuthenticatedEncryption/AuthenticatedEncryption.csproj
+++ b/AuthenticatedEncryption/AuthenticatedEncryption.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.4</TargetFrameworks>
+    <VersionPrefix>3.0.0</VersionPrefix>
+    <TargetFrameworks>net45;net8.0</TargetFrameworks>
     <AssemblyName>AuthenticatedEncryption</AssemblyName>
     <PackageId>AuthenticatedEncryption</PackageId>
     <PackageProjectUrl>https://github.com/trustpilot/nuget-authenticated-encryption</PackageProjectUrl>
@@ -15,11 +15,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The library was very outdated, and targeting netstandard1.4 is unfortunately not secure anymore - as it pulls in old implicit dependencies, like System.Net.Http 4.3.0


### Checklist ✅
- [x] My changes generate no new warnings
- [x] New and existing tests are passing locally
